### PR TITLE
Feat popular plugins

### DIFF
--- a/src/main/resources/common-plugins.yml
+++ b/src/main/resources/common-plugins.yml
@@ -19,6 +19,9 @@ CoreProtect:
 CrazyCrates:
   platform: modrinth
   modrinth-project-id: r3BBZyf3
+DecentHolograms:
+  platform: spigot
+  spigot-resource-id: 96927
 DeluxeMenus:
   platform: spigot
   spigot-resource-id: 11734
@@ -118,6 +121,9 @@ squaremap:
 SunLight:
   platform: spigot
   spigot-resource-id: 67733
+TAB:
+  platform: github
+  github-repo: "NEZNAMY/TAB"
 TabTPS:
   platform: modrinth
   modrinth-project-id: cUhi3iB2
@@ -127,6 +133,9 @@ Tebex:
 Tweakin:
   platform: spigot
   spigot-resource-id: 93444
+UltraCosmetics:
+  platform: spigot
+  spigot-resource-id: 10905
 Vault:
   platform: spigot
   spigot-resource-id: 34315
@@ -148,12 +157,3 @@ VillagerMarket:
 WorldEdit:
   platform: modrinth
   modrinth-project-id: 1u6JkXh5
-TAB:
-  platform: github
-  github-repo: "NEZNAMY/TAB"
-UltraCosmetics:
-  platform: spigot
-  spigot-resource-id: 10905
-DecentHolograms:
-  platform: spigot
-  spigot-resource-id: 96927


### PR DESCRIPTION
## Description

This PR includes two changes:

- **fix:** switched the download source for the Plan plugin from Spigot to GitHub. The Spigot download is broken and unreliable; GitHub is where the plugin is officially released, making it the most stable and up-to-date option.
- **feat:** added support for three widely-used plugins: TAB, UltraCosmetics, and DecentHolograms.

## Notes

If the maintainer is open to it, I can continue adding more well-known plugins in follow-up contributions.