### PR TITLE
Authenticate GitHub asset downloads for private repositories

### DIFF
--- a/api/src/main/java/org/lushplugins/pluginupdater/api/platform/github/GithubVersionChecker.java
+++ b/api/src/main/java/org/lushplugins/pluginupdater/api/platform/github/GithubVersionChecker.java
@@ -1,6 +1,5 @@
 package org.lushplugins.pluginupdater.api.platform.github;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.lushplugins.pluginupdater.api.platform.PlatformData;
@@ -14,6 +13,9 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class GithubVersionChecker implements VersionChecker {
 
@@ -34,8 +36,31 @@ public class GithubVersionChecker implements VersionChecker {
         }
 
         JsonObject releaseJson = getLatestRelease(pluginData, githubData);
-        JsonArray assetsJson = releaseJson.get("assets").getAsJsonArray();
-        return assetsJson.get(0).getAsJsonObject().get("browser_download_url").getAsString();
+        JsonObject assetJson = releaseJson.get("assets").getAsJsonArray().get(0).getAsJsonObject();
+
+        String token = githubData.getToken();
+        if (token != null && !token.isEmpty()) {
+            return assetJson.get("url").getAsString();
+        }
+
+        return assetJson.get("browser_download_url").getAsString();
+    }
+
+    @Override
+    public Map<String, String> getDownloadHeaders(PluginData pluginData, PlatformData platformData) {
+        if (!(platformData instanceof GithubData githubData)) {
+            return Collections.emptyMap();
+        }
+
+        String token = githubData.getToken();
+        if (token == null || token.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer " + token);
+        headers.put("Accept", "application/octet-stream");
+        return headers;
     }
 
     private JsonObject getLatestRelease(PluginData pluginData, GithubData githubData) throws IOException, InterruptedException {

--- a/api/src/main/java/org/lushplugins/pluginupdater/api/version/VersionChecker.java
+++ b/api/src/main/java/org/lushplugins/pluginupdater/api/version/VersionChecker.java
@@ -15,6 +15,8 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Collections;
+import java.util.Map;
 import java.util.logging.Level;
 
 @SuppressWarnings("CodeBlock2Expr")
@@ -22,6 +24,10 @@ public interface VersionChecker {
     String getLatestVersion(PluginData pluginData, PlatformData platformData) throws IOException, InterruptedException;
 
     String getDownloadUrl(PluginData pluginData, PlatformData platformData) throws IOException, InterruptedException;
+
+    default Map<String, String> getDownloadHeaders(PluginData pluginData, PlatformData platformData) throws IOException, InterruptedException {
+        return Collections.emptyMap();
+    }
 
     default boolean isUpdateAvailable(PluginData pluginData, PlatformData platformData) throws IOException, InterruptedException {
         String currentVersion = pluginData.getCurrentVersion();
@@ -58,6 +64,9 @@ public interface VersionChecker {
         URL url = URI.create(downloadUrl).toURL();
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.addRequestProperty("User-Agent", "PluginUpdater/" + UpdaterConstants.VERSION);
+        for (Map.Entry<String, String> header : getDownloadHeaders(pluginData, platformData).entrySet()) {
+            connection.addRequestProperty(header.getKey(), header.getValue());
+        }
         connection.setInstanceFollowRedirects(true);
         HttpURLConnection.setFollowRedirects(true);
 


### PR DESCRIPTION
Closes #92 (https://github.com/OakLoaf/PluginUpdater/issues/92)

## Summary

The GitHub release download flow silently failed for private repositories. The `/releases/latest` metadata request was correctly authenticated with the configured token, but the subsequent download step used the `browser_download_url` field with no authentication, which only works for public releases.

## Changes

- `GithubVersionChecker#getDownloadUrl`: when a token is configured, return the asset's API URL (`assets[0].url`) instead of `browser_download_url`. Public repos are unaffected.
- `GithubVersionChecker#getDownloadHeaders` (new override): when a token is configured, return `Authorization: Bearer <token>` and `Accept: application/octet-stream`. Both headers are required — without `Accept: application/octet-stream`, the GitHub API returns the asset metadata JSON instead of the binary.
- `VersionChecker`: added a default `getDownloadHeaders(PluginData, PlatformData)` method returning an empty map, and applied the returned headers on the `HttpURLConnection` inside `download()`. This keeps the Hangar, Modrinth, and Spigot checkers untouched and avoids any breaking changes to the public API.

## Notes

- Redirects are followed as before. On Java 12+, `HttpURLConnection` drops the `Authorization` header on cross-origin redirects, which is the correct behavior here since GitHub redirects to a pre-signed S3 URL that does not need the token.
- Public repositories continue to use `browser_download_url` with no extra headers, so behavior for existing users is unchanged.

## Test plan

- [x] Built the shaded plugin jar and loaded it on a test server
- [x] Configured a private GitHub repository with a valid token — update downloaded successfully
- [x] Verified public GitHub repositories still download correctly
- [x] Tested on a real PaperMC 1.20.6 server — update downloaded and applied successfully
