### PR TITLE
✨ Add server version filtering to ModrinthSource

### DIFF
--- a/common/api/src/main/java/org/lushplugins/pluginupdater/api/source/type/ModrinthSource.java
+++ b/common/api/src/main/java/org/lushplugins/pluginupdater/api/source/type/ModrinthSource.java
@@ -24,9 +24,15 @@ public class ModrinthSource implements Source {
     public static final String NAME = "modrinth";
 
     private final List<String> loaders;
+    private String serverVersion = null;
 
     public ModrinthSource(List<String> loaders) {
         this.loaders = loaders;
+    }
+
+    public ModrinthSource(List<String> loaders, String serverVersion) {
+        this(loaders);
+        this.serverVersion = serverVersion;
     }
 
     @Override
@@ -65,6 +71,10 @@ public class ModrinthSource implements Source {
                 .map(s -> "%22" + s + "%22")
                 .collect(Collectors.joining(",", "[", "]")))
             .append("&include_changelog=false");
+
+        if (serverVersion != null) {
+            uriBuilder.append("&game_versions=").append("[%22").append(serverVersion).append("%22]");
+        }
 
 
         if (modrinthData.filtersReleaseChannel()) {

--- a/platform/paper-api/src/main/java/org/lushplugins/pluginupdater/paper/api/plugin/PaperPluginInfo.java
+++ b/platform/paper-api/src/main/java/org/lushplugins/pluginupdater/paper/api/plugin/PaperPluginInfo.java
@@ -1,7 +1,9 @@
 package org.lushplugins.pluginupdater.paper.api.plugin;
 
+import io.papermc.paper.ServerBuildInfo;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.lushplugins.pluginupdater.api.source.SourceRegistry;
 import org.lushplugins.pluginupdater.api.source.type.GeyserSource;
@@ -20,9 +22,10 @@ public record PaperPluginInfo(Plugin plugin) implements PluginInfo {
 
     static {
         SourceRegistry.register(new GeyserSource("spigot"));
-        SourceRegistry.register(new ModrinthSource(List.of(
-            "bukkit", "spigot", "paper", "purpur", "folia"
-        )));
+
+        SourceRegistry.register(new ModrinthSource(
+                List.of("bukkit", "spigot", "paper", "purpur", "folia"),
+                ServerBuildInfo.buildInfo().minecraftVersionId()));
     }
 
     @Override
@@ -31,8 +34,8 @@ public record PaperPluginInfo(Plugin plugin) implements PluginInfo {
     }
 
     @Override
-    public String getVersion() {
-        return plugin.getDescription().getVersion();
+    public @NotNull String getVersion() {
+        return plugin.getPluginMeta().getVersion();
     }
 
     @Override


### PR DESCRIPTION
Velocity Modrinth could support that too, in that case Modrinth uses vanilla versions for velocity plugins trough and velocity their own versions, not sure what the correct way around this would be.

Another Option would be to make that fully configurable, would be helpful for Velocity but not needed for Paper.

Improves: #94.
Implements: #110.