### PR TITLE
Major enhancements to CLI implementation

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -68,7 +68,7 @@ jobs:
         if: env.RELEASE_TYPE == 'release'
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: platform/**-plugin/build/libs/*.jar
+          file: 'platform/{*-plugin,cli}/build/libs/*.jar'
           file_glob: true
           asset_name: ${{ github.event.repository.name }}-${{ env.VERSION }}
           tag: v${{ env.VERSION }}

--- a/platform/cli/build.gradle.kts
+++ b/platform/cli/build.gradle.kts
@@ -20,15 +20,15 @@ tasks {
     }
 
     shadowJar {
-        archiveFileName.set("${rootProject.name}-CLI-${project.version}.jar")
+        archiveFileName.set("${rootProject.name}-cli-${project.version}.jar")
     }
 }
 
 tasks.processResources {
     from(project(":platform:paper-plugin").file("src/main/resources/common-plugins.yml")) {
-        rename { "paper-common-plugins.yml" }
+        rename { "common-plugins/paper.yml" }
     }
     from(project(":platform:velocity-plugin").file("src/main/resources/common-plugins.yml")) {
-        rename { "velocity-common-plugins.yml" }
+        rename { "common-plugins/velocity.yml" }
     }
 }

--- a/platform/cli/build.gradle.kts
+++ b/platform/cli/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("com.gradleup.shadow")
+}
+
 dependencies {
     api(project(":common:impl"))
     implementation("io.github.revxrsal:lamp.cli:4.0.0-rc.18")
@@ -5,14 +9,17 @@ dependencies {
     api("com.electronwill.night-config:json:3.9.0")
 }
 
-tasks{
+tasks {
     jar {
-        archiveFileName.set("${rootProject.name}-cli-${project.version}.jar")
-
-        manifest.attributes (
+        manifest.attributes(
             "Main-Class" to "org.lushplugins.pluginupdater.cli.PluginUpdaterCLI"
         )
     }
+
+    shadowJar {
+        archiveFileName.set("${rootProject.name}-CLI-${project.version}.jar")
+    }
+}
 
 tasks.processResources {
     from(project(":platform:paper-plugin").file("src/main/resources/common-plugins.yml")) {

--- a/platform/cli/build.gradle.kts
+++ b/platform/cli/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     api(project(":common:impl"))
     implementation("io.github.revxrsal:lamp.cli:4.0.0-rc.18")
     api("net.kyori:adventure-text-minimessage:5.2.0")
+    implementation("net.kyori:adventure-text-serializer-ansi:5.2.0")
     api("com.electronwill.night-config:json:3.9.0")
 }
 

--- a/platform/cli/build.gradle.kts
+++ b/platform/cli/build.gradle.kts
@@ -8,12 +8,14 @@ dependencies {
     api("net.kyori:adventure-text-minimessage:5.2.0")
     implementation("net.kyori:adventure-text-serializer-ansi:5.2.0")
     api("com.electronwill.night-config:json:3.9.0")
+    implementation("org.jline:jline:3.30.16")
 }
 
 tasks {
     jar {
         manifest.attributes(
-            "Main-Class" to "org.lushplugins.pluginupdater.cli.PluginUpdaterCLI"
+            "Main-Class" to "org.lushplugins.pluginupdater.cli.PluginUpdaterCLI",
+            "Enable-Native-Access" to "ALL-UNNAMED"
         )
     }
 

--- a/platform/cli/build.gradle.kts
+++ b/platform/cli/build.gradle.kts
@@ -13,4 +13,12 @@ tasks{
             "Main-Class" to "org.lushplugins.pluginupdater.cli.PluginUpdaterCLI"
         )
     }
+
+tasks.processResources {
+    from(project(":platform:paper-plugin").file("src/main/resources/common-plugins.yml")) {
+        rename { "paper-common-plugins.yml" }
+    }
+    from(project(":platform:velocity-plugin").file("src/main/resources/common-plugins.yml")) {
+        rename { "velocity-common-plugins.yml" }
+    }
 }

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/PluginUpdaterCLI.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/PluginUpdaterCLI.java
@@ -45,7 +45,7 @@ public class PluginUpdaterCLI implements UpdaterPlugin {
 
     @Override
     public Path getDataPath() {
-        return pluginsFolder.resolve(System.getProperty("data-folder", "PluginUpdater"));
+        return Path.of(System.getProperty("data-folder", "PluginUpdater"));
     }
 
     @Override
@@ -107,14 +107,14 @@ public class PluginUpdaterCLI implements UpdaterPlugin {
         try {
             PluginUpdaterCLI cli = prepareCLI();
 
-            String finalCommonPluginsFile = cli.getPlatform() == Platform.VELOCITY ? "velocity-common-plugins.yml" : "paper-common-plugins.yml";
+            String commonPluginsFile = "common-plugins/" + (cli.getPlatform() == Platform.VELOCITY ? "velocity.yml" : "paper.yml");
             new UpdaterImpl<>(
                 new CLIPlatform(cli),
                 cli,
                 new CLICommandHandler(),
                 List.of(
                         ModrinthCollector::new,
-                        updater -> new CommonPluginCollector(updater, finalCommonPluginsFile)
+                        updater -> new CommonPluginCollector(updater, commonPluginsFile)
                 )
             );
         } catch (Exception e) {

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/PluginUpdaterCLI.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/PluginUpdaterCLI.java
@@ -13,6 +13,7 @@ import org.lushplugins.pluginupdater.cli.plugin.parser.BukkitInfoParser;
 import org.lushplugins.pluginupdater.cli.plugin.parser.InfoParser;
 import org.lushplugins.pluginupdater.cli.plugin.parser.VelocityInfoParser;
 import org.lushplugins.pluginupdater.common.UpdaterImpl;
+import org.lushplugins.pluginupdater.common.collector.CommonPluginCollector;
 import org.lushplugins.pluginupdater.common.collector.ModrinthCollector;
 import org.lushplugins.pluginupdater.common.platform.UpdaterPlugin;
 
@@ -22,6 +23,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class PluginUpdaterCLI implements UpdaterPlugin {
@@ -102,16 +104,22 @@ public class PluginUpdaterCLI implements UpdaterPlugin {
     }
 
     public static void main(String[] args) {
-        PluginUpdaterCLI cli = prepareCLI();
+        try {
+            PluginUpdaterCLI cli = prepareCLI();
 
-        new UpdaterImpl<>(
-            new CLIPlatform(cli),
-            cli,
-            new CLICommandHandler(),
-            List.of(
-                ModrinthCollector::new
-            )
-        );
+            String finalCommonPluginsFile = cli.getPlatform() == Platform.VELOCITY ? "velocity-common-plugins.yml" : "paper-common-plugins.yml";
+            new UpdaterImpl<>(
+                new CLIPlatform(cli),
+                cli,
+                new CLICommandHandler(),
+                List.of(
+                        ModrinthCollector::new,
+                        updater -> new CommonPluginCollector(updater, finalCommonPluginsFile)
+                )
+            );
+        } catch (Exception e) {
+            UpdaterConstants.LOGGER.log(Level.WARNING, "An error occurred while running the PluginUpdater CLI", e);
+        }
     }
 
     public enum Platform {

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/PluginUpdaterCLI.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/PluginUpdaterCLI.java
@@ -113,8 +113,8 @@ public class PluginUpdaterCLI implements UpdaterPlugin {
                 cli,
                 new CLICommandHandler(),
                 List.of(
-                        ModrinthCollector::new,
-                        updater -> new CommonPluginCollector(updater, commonPluginsFile)
+                    ModrinthCollector::new,
+                    updater -> new CommonPluginCollector(updater, commonPluginsFile)
                 )
             );
         } catch (Exception e) {

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/PluginUpdaterCLI.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/PluginUpdaterCLI.java
@@ -45,7 +45,7 @@ public class PluginUpdaterCLI implements UpdaterPlugin {
 
     @Override
     public Path getDataPath() {
-        return pluginsFolder.resolve("PluginUpdater");
+        return pluginsFolder.resolve(System.getProperty("data-folder", "PluginUpdater"));
     }
 
     @Override

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/CLICommandHandler.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/CLICommandHandler.java
@@ -1,6 +1,8 @@
 package org.lushplugins.pluginupdater.cli.command;
 
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.ansi.ANSIComponentSerializer;
 import org.lushplugins.pluginupdater.common.UpdaterImpl;
 import org.lushplugins.pluginupdater.common.platform.CommandHandler;
 import revxrsal.commands.Lamp;
@@ -14,7 +16,8 @@ public class CLICommandHandler implements CommandHandler {
     public Lamp.Builder<?> prepareLamp() {
         return CLILamp.builder()
             .defaultMessageSender((actor, input) -> {
-                actor.sendRawMessage(MiniMessage.miniMessage().stripTags(input));
+                Component message = MiniMessage.miniMessage().deserialize(input);
+                actor.sendRawMessage(ANSIComponentSerializer.ansi().serialize(message));
             });
     }
 

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/CLICommandHandler.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/CLICommandHandler.java
@@ -3,30 +3,107 @@ package org.lushplugins.pluginupdater.cli.command;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.ansi.ANSIComponentSerializer;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.UserInterruptException;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
 import org.lushplugins.pluginupdater.common.UpdaterImpl;
 import org.lushplugins.pluginupdater.common.platform.CommandHandler;
 import revxrsal.commands.Lamp;
 import revxrsal.commands.cli.CLILamp;
 import revxrsal.commands.cli.ConsoleActor;
+import revxrsal.commands.cli.actor.ActorFactory;
 import revxrsal.commands.command.CommandActor;
 
+import java.io.IOException;
+import java.nio.file.Path;
+
 public class CLICommandHandler implements CommandHandler {
+
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
+    private static final ANSIComponentSerializer ANSI =
+            ANSIComponentSerializer.ansi();
 
     @Override
     public Lamp.Builder<?> prepareLamp() {
         return CLILamp.builder()
-            .defaultMessageSender((actor, input) -> {
-                Component message = MiniMessage.miniMessage().deserialize(input);
-                actor.sendRawMessage(ANSIComponentSerializer.ansi().serialize(message));
-            });
+                .defaultMessageSender((actor, input) -> {
+                    Component message = MINI_MESSAGE.deserialize(input);
+                    actor.sendRawMessage(ANSI.serialize(message));
+                });
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void registerLampCommands(UpdaterImpl<?> updater, Lamp<?> lamp) {
         CommandHandler.super.registerLampCommands(updater, lamp);
         lamp.register(new StopCommand());
 
-        ((Lamp<ConsoleActor>) lamp).accept(CLILamp.pollStdin());
+        startConsole((Lamp<ConsoleActor>) lamp);
+    }
+
+    private void startConsole(Lamp<ConsoleActor> lamp) {
+        ConsoleActor actor =
+                ActorFactory.defaultFactory().createForStdIo(lamp);
+
+        try (Terminal terminal = TerminalBuilder.builder()
+                .system(true)
+                .build()) {
+
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .appName("plugin-updater")
+                    .completer(new LampCompleter(lamp, actor))
+                    .variable(
+                            LineReader.HISTORY_FILE,
+                            Path.of(".plugin-updater-history")
+                    )
+                    .option(LineReader.Option.HISTORY_IGNORE_DUPS, true)
+                    .option(LineReader.Option.HISTORY_BEEP, false)
+                    .build();
+
+            printWelcome(terminal);
+
+            while (true) {
+                try {
+                    String input = reader.readLine("> ");
+
+                    if (input.isBlank()) {
+                        continue;
+                    }
+
+                    lamp.dispatch(actor, input);
+
+                } catch (UserInterruptException ignored) {
+                    // Ctrl+C
+                    lamp.dispatch(actor, "stop");
+                    break;
+                }
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Failed to initialize CLI terminal",
+                    e
+            );
+        }
+    }
+
+    private void printWelcome(Terminal terminal) {
+        terminal.writer().println();
+        terminal.writer().println(
+                ANSI.serialize(MINI_MESSAGE.deserialize(
+                        "<gradient:#5e81ac:#88c0d0><bold>PluginUpdater CLI</bold></gradient>"
+                ))
+        );
+        terminal.writer().println(
+                ANSI.serialize(MINI_MESSAGE.deserialize(
+                        "<dark_gray>Type <white>upd <tab></white> for available commands. Visit https://github.com/OakLoaf/PluginUpdater/wiki/PluginUpdater-CLI for more infos."
+                ))
+        );
+        terminal.writer().println();
+        terminal.writer().flush();
     }
 
     @Override

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/CLICommandHandler.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/CLICommandHandler.java
@@ -15,7 +15,6 @@ import revxrsal.commands.cli.CLILamp;
 import revxrsal.commands.cli.ConsoleActor;
 import revxrsal.commands.cli.actor.ActorFactory;
 import revxrsal.commands.command.CommandActor;
-
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -28,10 +27,10 @@ public class CLICommandHandler implements CommandHandler {
     @Override
     public Lamp.Builder<?> prepareLamp() {
         return CLILamp.builder()
-                .defaultMessageSender((actor, input) -> {
-                    Component message = MINI_MESSAGE.deserialize(input);
-                    actor.sendRawMessage(ANSI.serialize(message));
-                });
+            .defaultMessageSender((actor, input) -> {
+                Component message = MINI_MESSAGE.deserialize(input);
+                actor.sendRawMessage(ANSI.serialize(message));
+            });
     }
 
     @Override
@@ -44,24 +43,23 @@ public class CLICommandHandler implements CommandHandler {
     }
 
     private void startConsole(Lamp<ConsoleActor> lamp) {
-        ConsoleActor actor =
-                ActorFactory.defaultFactory().createForStdIo(lamp);
+        ConsoleActor actor = ActorFactory.defaultFactory().createForStdIo(lamp);
 
         try (Terminal terminal = TerminalBuilder.builder()
-                .system(true)
-                .build()) {
+            .system(true)
+            .build()) {
 
             LineReader reader = LineReaderBuilder.builder()
-                    .terminal(terminal)
-                    .appName("plugin-updater")
-                    .completer(new LampCompleter(lamp, actor))
-                    .variable(
-                            LineReader.HISTORY_FILE,
-                            Path.of(".plugin-updater-history")
-                    )
-                    .option(LineReader.Option.HISTORY_IGNORE_DUPS, true)
-                    .option(LineReader.Option.HISTORY_BEEP, false)
-                    .build();
+                .terminal(terminal)
+                .appName("plugin-updater")
+                .completer(new LampCompleter(lamp, actor))
+                .variable(
+                    LineReader.HISTORY_FILE,
+                    Path.of(".plugin-updater-history")
+                )
+                .option(LineReader.Option.HISTORY_IGNORE_DUPS, true)
+                .option(LineReader.Option.HISTORY_BEEP, false)
+                .build();
 
             printWelcome(terminal);
 
@@ -83,24 +81,21 @@ public class CLICommandHandler implements CommandHandler {
             }
 
         } catch (IOException e) {
-            throw new RuntimeException(
-                    "Failed to initialize CLI terminal",
-                    e
-            );
+            throw new RuntimeException("Failed to initialize CLI terminal", e);
         }
     }
 
     private void printWelcome(Terminal terminal) {
         terminal.writer().println();
         terminal.writer().println(
-                ANSI.serialize(MINI_MESSAGE.deserialize(
-                        "<gradient:#5e81ac:#88c0d0><bold>PluginUpdater CLI</bold></gradient>"
-                ))
+            ANSI.serialize(MINI_MESSAGE.deserialize(
+                "<gradient:#5e81ac:#88c0d0><bold>PluginUpdater CLI</bold></gradient>"
+            ))
         );
         terminal.writer().println(
-                ANSI.serialize(MINI_MESSAGE.deserialize(
-                        "<dark_gray>Type <white>upd <tab></white> for available commands. Visit https://github.com/OakLoaf/PluginUpdater/wiki/PluginUpdater-CLI for more infos."
-                ))
+            ANSI.serialize(MINI_MESSAGE.deserialize(
+                "<dark_gray>Type <white>upd <tab></white> for available commands. Visit https://github.com/OakLoaf/PluginUpdater/wiki/PluginUpdater-CLI for more infos."
+            ))
         );
         terminal.writer().println();
         terminal.writer().flush();

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/LampCompleter.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/LampCompleter.java
@@ -15,8 +15,8 @@ public final class LampCompleter implements Completer {
     private final ConsoleActor actor;
 
     public LampCompleter(
-            Lamp<ConsoleActor> lamp,
-            ConsoleActor actor
+        Lamp<ConsoleActor> lamp,
+        ConsoleActor actor
     ) {
         this.lamp = lamp;
         this.actor = actor;
@@ -24,9 +24,9 @@ public final class LampCompleter implements Completer {
 
     @Override
     public void complete(
-            LineReader reader,
-            ParsedLine line,
-            List<Candidate> candidates
+        LineReader reader,
+        ParsedLine line,
+        List<Candidate> candidates
     ) {
         String input = line.line();
 

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/LampCompleter.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/command/LampCompleter.java
@@ -1,0 +1,37 @@
+package org.lushplugins.pluginupdater.cli.command;
+
+import org.jline.reader.Candidate;
+import org.jline.reader.Completer;
+import org.jline.reader.LineReader;
+import org.jline.reader.ParsedLine;
+import revxrsal.commands.Lamp;
+import revxrsal.commands.cli.ConsoleActor;
+
+import java.util.List;
+
+public final class LampCompleter implements Completer {
+
+    private final Lamp<ConsoleActor> lamp;
+    private final ConsoleActor actor;
+
+    public LampCompleter(
+            Lamp<ConsoleActor> lamp,
+            ConsoleActor actor
+    ) {
+        this.lamp = lamp;
+        this.actor = actor;
+    }
+
+    @Override
+    public void complete(
+            LineReader reader,
+            ParsedLine line,
+            List<Candidate> candidates
+    ) {
+        String input = line.line();
+
+        for (String suggestion : lamp.autoCompleter().complete(actor, input)) {
+            candidates.add(new Candidate(suggestion));
+        }
+    }
+}

--- a/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/platform/CLIPlatform.java
+++ b/platform/cli/src/main/java/org/lushplugins/pluginupdater/cli/platform/CLIPlatform.java
@@ -18,7 +18,6 @@ import java.util.function.UnaryOperator;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class CLIPlatform implements UpdaterPlatform<Object> {


### PR DESCRIPTION
The current main state of the CLI integration was not really standalone usable for me. No proper integration into already existing common plugin lists, no shadow of the dependencies so running it finds them no way to specify a different folder for the PU Folder so it can be shared. 

There are still some open issues/questions:
- [x] Color Support for the CLI would be great
- [ ] Hover Effects should get serialized so you can still see it
- [x] Tab Completion
- [x] Maybe a last commands file so after a restart you can continue where you stopped
- [x] Cursor Support - currently when you mistyped smt you have to delete everything because arrow keys doesn't work
- [ ] No necessarily CLI related but a proper help cmd which outputs a list of all cmds would be great
- [ ] The Json Reference i suggested in https://github.com/OakLoaf/PluginUpdater/issues/154#issue-4942823156
- [ ] Documentation of the CLI Version

Lmk how you want to continue with the open points. If i should also pr them. 

Hope you are open to integrate these changes i made in the pr, these are the Baselevel needs. 

Some things you maybe want me to change:
- Make the codestyle better for the common plugins selection
-  Use a local variable for the resolved PU data folder
- Change back from ``CLI`` to ``cli``