### PR TITLE
Add Discord webhook notifications for plugin downloads (#157)

### DIFF
--- a/common/impl/build.gradle.kts
+++ b/common/impl/build.gradle.kts
@@ -3,4 +3,5 @@ dependencies {
 
     api("io.github.revxrsal:lamp.common:4.0.0-rc.18")
     api("com.electronwill.night-config:yaml:3.9.0")
+    api("io.github.4drian3d:jdwebhooks:2.0.0")
 }

--- a/common/impl/src/main/java/org/lushplugins/pluginupdater/common/UpdaterImpl.java
+++ b/common/impl/src/main/java/org/lushplugins/pluginupdater/common/UpdaterImpl.java
@@ -10,6 +10,7 @@ import org.lushplugins.pluginupdater.common.command.annotation.CommandPermission
 import org.lushplugins.pluginupdater.common.command.annotation.PluginName;
 import org.lushplugins.pluginupdater.common.command.response.StringMessageResponseHandler;
 import org.lushplugins.pluginupdater.common.config.ConfigManager;
+import org.lushplugins.pluginupdater.common.notifier.DiscordWebhookNotifier;
 import org.lushplugins.pluginupdater.common.platform.CommandHandler;
 import org.lushplugins.pluginupdater.common.platform.UpdaterPlugin;
 import org.lushplugins.pluginupdater.common.updater.UpdateHandler;
@@ -30,6 +31,7 @@ public class UpdaterImpl<T> {
     private final List<PluginDataCollector.Factory> collectors;
     private final UpdateHandler<T> updateHandler;
     private final ConfigManager config;
+    private DiscordWebhookNotifier discordWebhookNotifier;
 
     public UpdaterImpl(UpdaterPlatform<T> platform, UpdaterPlugin updaterPlugin, CommandHandler commandPlatform, List<PluginDataCollector.Factory> collectors) {
         this.platform = platform;
@@ -42,6 +44,13 @@ public class UpdaterImpl<T> {
 
         config = new ConfigManager(this);
         config.reload();
+        
+        // Initialize Discord webhook notifier
+        this.discordWebhookNotifier = new DiscordWebhookNotifier(
+            updaterPlugin.getLogger(),
+            config.isDiscordWebhookEnabled(),
+            config.getDiscordWebhookUrl()
+        );
 
         Lamp<?> lamp = commandPlatform.prepareLamp()
             .permissionFactory(new CommandPermissionFactory(this))
@@ -84,6 +93,9 @@ public class UpdaterImpl<T> {
 
     public void shutdown() {
         updateHandler.shutdown();
+        if (discordWebhookNotifier != null) {
+            discordWebhookNotifier.close();
+        }
     }
 
     public UpdaterPlatform<T> platform() {
@@ -108,6 +120,14 @@ public class UpdaterImpl<T> {
 
     public ConfigManager config() {
         return config;
+    }
+
+    public DiscordWebhookNotifier discordWebhookNotifier() {
+        return discordWebhookNotifier;
+    }
+
+    public void setDiscordWebhookNotifier(DiscordWebhookNotifier notifier) {
+        this.discordWebhookNotifier = notifier;
     }
 
     public CompletableFuture<List<PluginData>> collectUnknownPlugins() {

--- a/common/impl/src/main/java/org/lushplugins/pluginupdater/common/config/ConfigManager.java
+++ b/common/impl/src/main/java/org/lushplugins/pluginupdater/common/config/ConfigManager.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import org.lushplugins.pluginupdater.api.updater.PluginData;
 import org.lushplugins.pluginupdater.common.config.deserializer.PluginDataDeserializer;
 import org.lushplugins.pluginupdater.common.UpdaterImpl;
+import org.lushplugins.pluginupdater.common.notifier.DiscordWebhookNotifier;
 import org.lushplugins.pluginupdater.common.updater.UpdateHandler;
 import org.lushplugins.pluginupdater.common.util.ConfigUtil;
 
@@ -23,6 +24,8 @@ public class ConfigManager {
     private final Map<String, PluginData> plugins = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     private final Set<String> disabledPlugins = new HashSet<>();
     private Messages messages;
+    private boolean discordWebhookEnabled;
+    private String discordWebhookUrl;
 
     public ConfigManager(UpdaterImpl<?> updater) {
         this.updater = updater;
@@ -46,6 +49,15 @@ public class ConfigManager {
         );
 
         this.allowDownloads = config.getOrElse("allow-downloads", true);
+
+        Config discordConfig = config.get("discord-webhook");
+        if (discordConfig != null) {
+            this.discordWebhookEnabled = discordConfig.getOrElse("enabled", false);
+            this.discordWebhookUrl = discordConfig.getOrElse("webhook-url", "");
+        } else {
+            this.discordWebhookEnabled = false;
+            this.discordWebhookUrl = "";
+        }
 
         Config messagesConfig = config.get("messages");
         if (messagesConfig != null) {
@@ -90,6 +102,16 @@ public class ConfigManager {
                 updateHandler.queueBroadcastNotification();
             }
         });
+
+        // Reinitialize Discord webhook notifier with new config
+        if (updater.discordWebhookNotifier() != null) {
+            updater.discordWebhookNotifier().close();
+        }
+        updater.setDiscordWebhookNotifier(new DiscordWebhookNotifier(
+            updater.updaterPlugin().getLogger(),
+            this.discordWebhookEnabled,
+            this.discordWebhookUrl
+        ));
 
         config.close();
     }
@@ -140,6 +162,14 @@ public class ConfigManager {
 
     public String getMessage(String name, String def) {
         return messages.get(name, def);
+    }
+
+    public boolean isDiscordWebhookEnabled() {
+        return discordWebhookEnabled;
+    }
+
+    public String getDiscordWebhookUrl() {
+        return discordWebhookUrl;
     }
 
 

--- a/common/impl/src/main/java/org/lushplugins/pluginupdater/common/notifier/DiscordWebhookNotifier.java
+++ b/common/impl/src/main/java/org/lushplugins/pluginupdater/common/notifier/DiscordWebhookNotifier.java
@@ -1,0 +1,103 @@
+package org.lushplugins.pluginupdater.common.notifier;
+
+import io.github._4drian3d.jdwebhooks.component.Component;
+import io.github._4drian3d.jdwebhooks.component.ContainerableComponent;
+import io.github._4drian3d.jdwebhooks.webhook.WebHookClient;
+import io.github._4drian3d.jdwebhooks.webhook.WebHookExecution;
+import org.jetbrains.annotations.Nullable;
+import org.lushplugins.pluginupdater.api.updater.PluginData;
+import org.lushplugins.pluginupdater.api.version.Version;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class DiscordWebhookNotifier {
+    private final Logger logger;
+    private final WebHookClient webhookClient;
+    private final boolean enabled;
+
+    public DiscordWebhookNotifier(Logger logger, boolean enabled, @Nullable String webhookUrl) {
+        this.logger = logger;
+        this.enabled = enabled && webhookUrl != null && !webhookUrl.isBlank();
+
+        if (this.enabled) {
+            this.webhookClient = WebHookClient.fromURL(webhookUrl);
+        } else {
+            this.webhookClient = null;
+        }
+    }
+
+    public void notifyDownload(PluginData pluginData) {
+        if (!enabled || webhookClient == null) {
+            return;
+        }
+
+        try {
+            Version currentVersion = pluginData.currentVersion();
+            Optional<Version> latestVersionOpt = pluginData.latestVersion();
+
+            if (latestVersionOpt.isEmpty()) {
+                return;
+            }
+
+            Version latestVersion = latestVersionOpt.get();
+            String pluginName = pluginData.pluginName();
+
+            String versionString = String.format("%s → %s",
+                currentVersion.rawVersionString(),
+                latestVersion.rawVersionString()
+            );
+
+            List<ContainerableComponent> components = new ArrayList<>();
+
+            components.add(Component.textDisplay("**" + pluginName + " Updated**"));
+
+            components.add(Component.textDisplay("**Version:** " + versionString));
+
+            String versionDiff = pluginData.versionDifference().name();
+            if (!versionDiff.equals("UNKNOWN")) {
+                components.add(Component.textDisplay("**Update Type:** " + versionDiff));
+            }
+
+            pluginData.getChangelogUrl().ifPresent(s -> components.add(Component.textDisplay("**Changelog:** [View Changelog](" + s + ")")));
+
+            WebHookExecution webHook = WebHookExecution.builder()
+                .username("PluginUpdater")
+                .avatarURL("https://cdn.modrinth.com/data/IBSpJfbm/172c14d2cdb854064160fa627f9dd0043c1b79ee_96.webp")
+                .component(
+                    Component.container()
+                        .components(components)
+                        .accentColor(0x66b04f)
+                        .build()
+                )
+                .build();
+
+            webhookClient.executeWebHook(webHook)
+                .whenComplete((response, throwable) -> {
+                    int statusCode = response.statusCode();
+
+                    if (throwable != null) {
+                        logger.log(Level.WARNING, "Failed to send Discord webhook notification", throwable);
+                    } else if (statusCode < 200 || statusCode >= 300) {
+                        logger.log(
+                            Level.WARNING,
+                            () -> "Discord webhook returned unsuccessful response. Status code: "
+                                + statusCode
+                                + ", response: "
+                                + response
+                        );
+                    }
+                });
+
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Failed to send Discord webhook notification", e);
+        }
+    }
+
+    public void close() {
+        // Might come handy in the future
+    }
+}

--- a/common/impl/src/main/java/org/lushplugins/pluginupdater/common/updater/UpdateHandler.java
+++ b/common/impl/src/main/java/org/lushplugins/pluginupdater/common/updater/UpdateHandler.java
@@ -118,6 +118,12 @@ public class UpdateHandler<T> {
                         if (pluginData.downloadUpdate(updater.updaterPlugin().getDownloadDir())) {
                             pluginData.versionDifference(VersionDifference.UNKNOWN);
                             pluginData.setAlreadyDownloaded(true);
+                            
+                            // Send Discord webhook notification
+                            if (updater.discordWebhookNotifier() != null) {
+                                updater.discordWebhookNotifier().notifyDownload(pluginData);
+                            }
+                            
                             processingData.getFuture().complete(true);
                             break;
                         } else {

--- a/common/impl/src/main/resources/config.yml
+++ b/common/impl/src/main/resources/config.yml
@@ -3,6 +3,11 @@ check-updates-on-reload: true
 # Set to 'false' to disable all download features of PluginUpdater (May require restart)
 allow-downloads: true
 
+# Discord webhook configuration for download notifications
+discord-webhook:
+  enabled: false
+  webhook-url: ""
+
 # To learn how to configure plugins that require different sources check out the wiki: https://github.com/OakLoaf/PluginUpdater/wiki/PluginUpdater-Plugin
 plugins:
   PluginUpdater:


### PR DESCRIPTION
Implement basic Discord webhook support to send notifications when plugins are successfully downloaded. Uses jdwebhooks 2.0.0 library with Discord's Components V2 API.

## Changes:
- Add jdwebhooks 2.0.0 dependency to common/impl
- Create DiscordWebhookNotifier class for sending webhook notifications
- Add discord-webhook configuration section to config.yml (disabled by default)
- Update ConfigManager to load and reload webhook settings
- Integrate webhook notifications in UpdateHandler on successful downloads
- Update UpdaterImpl to initialize and manage webhook notifier lifecycle

## Webhook notifications include:
- Plugin name
- Version change (old → new)
- Update type (MAJOR, MINOR, PATCH, etc.)
- Changelog link (if available)

## Infos

Users can enable by setting discord-webhook.enabled to true and providing a webhook-url in config.yml.

Closes #157

- Config currently does not update automatically
- This implementation set both Avatar + Users - we could also not set that and use it from the Webhook. 
- Currently it was only implemented for Updates, Update available might be a feature i contribute

### AI Disclosure 

GitHub Copilot was used for most of the implementation, all code was manually verified & tested on paper. Additional Changes was made to ensure it works correctly.